### PR TITLE
Changes for Patch 10.0.0 plus new Dragonflight sets, but tooltips are broken

### DIFF
--- a/Appearances/10.lua
+++ b/Appearances/10.lua
@@ -1,0 +1,219 @@
+-- Appearances from Dragonflight (v.10.x)
+
+--
+-- LOCAL VARIABLES
+--
+
+local ALL = SetCollector.ALL
+local ANY = SetCollector.ANY
+
+-- Armor Type
+local CLOTH = SetCollector.CLOTH
+local LEATHER = SetCollector.LEATHER
+local MAIL = SetCollector.MAIL
+local PLATE = SetCollector.PLATE
+local ANY_ARMOR	= SetCollector.ANY_ARMOR
+
+-- Classes
+local DEATHKNIGHT = SetCollector.DEATHKNIGHT
+local DEMONHUNTER = SetCollector.DEMONHUNTER
+local DRUID = SetCollector.DRUID
+local EVOKER = SetCollector.EVOKER
+local HUNTER = SetCollector.HUNTER
+local MAGE = SetCollector.MAGE
+local MONK = SetCollector.MONK
+local PALADIN = SetCollector.PALADIN
+local PRIEST = SetCollector.PRIEST
+local ROGUE = SetCollector.ROGUE
+local SHAMAN = SetCollector.SHAMAN
+local WARLOCK = SetCollector.WARLOCK
+local WARRIOR = SetCollector.WARRIOR
+local ANY_CLASS = SetCollector.ANY_CLASS
+
+-- Factions
+local ALLIANCE = SetCollector.ALLIANCE
+local HORDE = SetCollector.HORDE
+local ANY_FACTION = SetCollector.ANY_FACTION
+
+-- Collection Types
+local OUTFITS = SetCollector.OUTFITS
+local ARTIFACT = SetCollector.ARTIFACT
+local LEGENDARY = SetCollector.LEGENDARY
+local RAID = SetCollector.RAID
+local DUNGEON = SetCollector.DUNGEON
+local CHALLENGE = SetCollector.CHALLENGE
+local PVP = SetCollector.PVP
+local EXPANSION = SetCollector.EXPANSION
+local CRAFTED = SetCollector.CRAFTED
+local OTHER = SetCollector.OTHER
+local CUSTOM = SetCollector.CUSTOM
+local HOLIDAY = SetCollector.HOLIDAY
+
+-- Obtainable
+local OBTAIN = SetCollector.OBTAIN
+local NO_OBTAIN = SetCollector.NO_OBTAIN
+
+-- Useable as Transmog
+local TRANSMOG = SetCollector.TRANSMOG
+local NO_TRANSMOG = SetCollector.NO_TRANSMOG
+
+-- Locations
+local NO_LOCATION = nil
+
+--
+-- LOCAL FUNCTIONS
+--
+
+local function A(...) return SetCollector:CreateAppearance(...) end
+local function CreateSet(...) return SetCollector:CreateSet(...) end
+local function CreateVariant(...) return SetCollector:CreateVariant(...) end
+local function IncludeSet(...) return SetCollector:IncludeSet(...) end
+local function AddSetsToDatabase(...) return SetCollector:AddSetsToDatabase(...) end
+
+local function GetCraftedAppearances()
+    local COLLECTION, VERSION = SetCollector.CRAFTED, 100000
+    sets = {
+        -- Primal Elements
+        IncludeSet(COLLECTION,11000,2749,PLATE,ANY_CLASS,ANY_FACTION), -- Primal Molten
+        IncludeSet(COLLECTION,11000,2743,CLOTH,ANY_CLASS,ANY_FACTION), -- Vibrant Wildercloth
+        IncludeSet(COLLECTION,11000,2745,MAIL,ANY_CLASS,ANY_FACTION), -- Flame-Touched
+        IncludeSet(COLLECTION,11000,2747,LEATHER,ANY_CLASS,ANY_FACTION), -- Life-Bound
+
+        -- Expedition Gear
+        IncludeSet(COLLECTION,11000,2698,PLATE,ANY_CLASS,ANY_FACTION), -- Crimson Combatant's Draconium Armor
+        IncludeSet(COLLECTION,11000,2691,CLOTH,ANY_CLASS,ANY_FACTION), -- Crimson Combatant's Wildercloth Regalia
+        IncludeSet(COLLECTION,11000,2694,MAIL,ANY_CLASS,ANY_FACTION), -- Crimson Combatant's Adamant Battlegear
+        IncludeSet(COLLECTION,11000,2688,LEATHER,ANY_CLASS,ANY_FACTION), -- Crimson Combatant's Resilient Armor
+    }
+    AddSetsToDatabase(VERSION, COLLECTION, sets)
+end
+
+local function GetDungeonAppearances()
+    local COLLECTION, VERSION = SetCollector.DUNGEON, 100000
+    sets = {
+        IncludeSet(COLLECTION,11000,2712,PLATE,ANY_CLASS,ANY_FACTION), -- Djaradin Battlegear / Djaradin Dungeon Battlegear
+        IncludeSet(COLLECTION,11000,2710,MAIL,ANY_CLASS,ANY_FACTION), -- Centaur Regalia / Centaur Dungeon Harness
+        IncludeSet(COLLECTION,11000,2703,CLOTH,ANY_CLASS,ANY_FACTION), -- Titan Keeper's Vestments / Titan Dungeonkeeper's Vestments
+        IncludeSet(COLLECTION,11000,2683,LEATHER,ANY_CLASS,ANY_FACTION), -- Tuskarr Battlegear / Ottuk Hide Armor
+    }
+    AddSetsToDatabase(VERSION, COLLECTION, sets)
+end
+
+local function GetExpansionAppearances()
+    local COLLECTION, VERSION = SetCollector.EXPANSION, 100000
+    sets = {
+        -- World and Weekly Quests
+        IncludeSet(COLLECTION,11000,2711,PLATE,ANY_CLASS,ANY_FACTION,2714,2713), -- Djaradin Battlegear / Wyrmforged Battlegear
+        IncludeSet(COLLECTION,11000,2706,MAIL,ANY_CLASS,ANY_FACTION,2708,2709), -- Centaur Regalia / Ohn'ahran Falconer's Regalia
+        IncludeSet(COLLECTION,11000,2701,CLOTH,ANY_CLASS,ANY_FACTION,2704,2705), -- Titan Keeper's Vestments / Cobalt Watcher's Vestments
+        IncludeSet(COLLECTION,11000,2681,LEATHER,ANY_CLASS,ANY_FACTION,2684,2587), -- Tuskarr Battlegear / Ottuk Hide Armor
+
+        -- Expedition Gear
+        IncludeSet(COLLECTION,11000,2697,PLATE,ANY_CLASS,ANY_FACTION,2700,2492,2699),
+        IncludeSet(COLLECTION,11000,2692,MAIL,ANY_CLASS,ANY_FACTION,2695,2696,2491),
+        IncludeSet(COLLECTION,11000,2685,LEATHER,ANY_CLASS,ANY_FACTION,2490,2687,2686),
+        IncludeSet(COLLECTION,11000,2689,CLOTH,ANY_CLASS,ANY_FACTION,2693,2690,2489),
+
+        -- Dracthyr Battlegear
+        IncludeSet(COLLECTION,11000,2672,MAIL,ANY_CLASS,ANY_FACTION,2673,2674,2675,2670),  -- Emerald, Crimson, Cobalt, Sandshaped, Obsidian
+
+        -- Valdrakken Civilian Clothing
+        IncludeSet(COLLECTION,11000,2582,ANY_ARMOR,ANY_CLASS,ANY_FACTION,2583,2584,2585,2586), 
+
+        -- Primal Elements
+        IncludeSet(COLLECTION,11000,2667,PLATE,ANY_CLASS,ANY_FACTION,2668,2748),  
+        IncludeSet(COLLECTION,11000,2661,CLOTH,ANY_CLASS,ANY_FACTION,2662,2742),
+        IncludeSet(COLLECTION,11000,2663,MAIL,ANY_CLASS,ANY_FACTION,2664,2744),
+        IncludeSet(COLLECTION,11000,2665,LEATHER,ANY_CLASS,ANY_FACTION,2666,2746),
+    }
+    AddSetsToDatabase(VERSION, COLLECTION, sets)
+end
+
+local function GetLegendaryAppearances()
+    local COLLECTION, VERSION = SetCollector.LEGENDARY, 100000
+    -- sets = {
+    --     IncludeSet(COLLECTION,11000,SET_ID,ANY_ARMOR,ANY_CLASS,ANY_FACTION,ALT_2,ALT_3,ALT_4),
+    -- }
+    -- AddSetsToDatabase(VERSION, COLLECTION, sets)
+end
+
+local function GetOtherAppearances()
+    local COLLECTION, VERSION = SetCollector.OTHER, 100000
+    -- sets = {
+    --     IncludeSet(COLLECTION,11000,SET_ID,ANY_ARMOR,ANY_CLASS,ANY_FACTION,ALT_2,ALT_3,ALT_4),
+    -- }
+    -- AddSetsToDatabase(VERSION, COLLECTION, sets)
+end
+
+local function GetPvPAppearances()
+    local COLLECTION, VERSION = SetCollector.PVP, 100000
+    sets = {
+        -- Dragonflight Season 1 (Aspirant)
+        IncludeSet(COLLECTION,11000,2715,PLATE,ANY_CLASS,ANY_FACTION), -- Crimson Aspirant's Plate Battlegear
+        IncludeSet(COLLECTION,11000,2707,MAIL,ANY_CLASS,ANY_FACTION), -- Crimson Aspirant's Chain Armor
+        IncludeSet(COLLECTION,11000,2702,CLOTH,ANY_CLASS,ANY_FACTION), -- Crimson Aspirant's Silk Vestments
+        IncludeSet(COLLECTION,11000,2682,LEATHER,ANY_CLASS,ANY_FACTION), -- Crimson Aspirant's Battlegarb
+
+        -- Dragonflight Season 1 (Gladiator, Alt = Elite)
+        IncludeSet(COLLECTION,11000,2716,ANY_ARMOR,MAGE,ANY_FACTION,2717), -- Crimson Gladiator's Silk Armor
+        IncludeSet(COLLECTION,11000,2718,ANY_ARMOR,PRIEST,ANY_FACTION,2719), -- Crimson Gladiator's Silk Armor
+        IncludeSet(COLLECTION,11000,2720,ANY_ARMOR,WARLOCK,ANY_FACTION,2721), -- Crimson Gladiator's Silk Armor
+        IncludeSet(COLLECTION,11000,2722,ANY_ARMOR,DRUID,ANY_FACTION,2723), -- Crimson Gladiator's Leather Armor
+        IncludeSet(COLLECTION,11000,2724,ANY_ARMOR,DEMONHUNTER,ANY_FACTION,2725), -- Crimson Gladiator's Leather Armor
+        IncludeSet(COLLECTION,11000,2726,ANY_ARMOR,MONK,ANY_FACTION,2727), -- Crimson Gladiator's Leather Armor
+        IncludeSet(COLLECTION,11000,2728,ANY_ARMOR,ROGUE,ANY_FACTION,2729), -- Crimson Gladiator's Leather Armor
+        IncludeSet(COLLECTION,11000,2730,ANY_ARMOR,EVOKER,ANY_FACTION,2731), -- Crimson Gladiator's Chain Armor
+        IncludeSet(COLLECTION,11000,2732,ANY_ARMOR,HUNTER,ANY_FACTION,2733), -- Crimson Gladiator's Chain Armor
+        IncludeSet(COLLECTION,11000,2734,ANY_ARMOR,SHAMAN,ANY_FACTION,2735), -- Crimson Gladiator's Chain Armor
+        IncludeSet(COLLECTION,11000,2736,ANY_ARMOR,DEATHKNIGHT,ANY_FACTION,2737), -- Crimson Gladiator's Plate Armor
+        IncludeSet(COLLECTION,11000,2738,ANY_ARMOR,PALADIN,ANY_FACTION,2739), -- Crimson Gladiator's Plate Armor
+        IncludeSet(COLLECTION,11000,2740,ANY_ARMOR,WARRIOR,ANY_FACTION,2741), -- Crimson Gladiator's Plate Armor
+    }
+    AddSetsToDatabase(VERSION, COLLECTION, sets)
+end
+
+local function GetRaidAppearances()
+    local COLLECTION, VERSION = SetCollector.RAID, 100000
+    sets = {
+        -- Vault of the Incarnates (N, H, M, RF)
+        IncludeSet(COLLECTION,11000,2601,ANY_ARMOR,DEATHKNIGHT,ANY_FACTION,2614,2615,2616), -- Haunted Frostbrood Remains
+        IncludeSet(COLLECTION,11000,2602,ANY_ARMOR,DEMONHUNTER,ANY_FACTION,2617,2618,2619), -- Skybound Avenger's Flightwear
+        IncludeSet(COLLECTION,11000,2603,ANY_ARMOR,DRUID,ANY_FACTION,2620,2622,2621), -- Lost Landcaller's Vesture
+        IncludeSet(COLLECTION,11000,2604,ANY_ARMOR,EVOKER,ANY_FACTION,2623,2624,2625), -- Scales of the Awakened
+        IncludeSet(COLLECTION,11000,2605,ANY_ARMOR,HUNTER,ANY_FACTION,2626,2628,2627), -- Stormwing Harrier's Camouflage
+        IncludeSet(COLLECTION,11000,2606,ANY_ARMOR,MAGE,ANY_FACTION,2629,2630,2631), -- Bindings of the Crystal Scholar
+        IncludeSet(COLLECTION,11000,2607,ANY_ARMOR,MONK,ANY_FACTION,2632,2633,2634), -- Wrappings of the Waking Fist
+        IncludeSet(COLLECTION,11000,2608,ANY_ARMOR,PALADIN,ANY_FACTION,2635,2637,2636), -- Virtuous Silver Cataphract
+        IncludeSet(COLLECTION,11000,2609,ANY_ARMOR,PRIEST,ANY_FACTION,2638,2640,2639), -- Draconic Hierophant's Finery
+        IncludeSet(COLLECTION,11000,2610,ANY_ARMOR,ROGUE,ANY_FACTION,2641,2642,2643), -- Vault Delver's Toolkit
+        IncludeSet(COLLECTION,11000,2611,ANY_ARMOR,SHAMAN,ANY_FACTION,2644,2646,2645), -- Elements of Infused Earth
+        IncludeSet(COLLECTION,11000,2612,ANY_ARMOR,WARLOCK,ANY_FACTION,2647,2648,2649), -- Scalesworn Cultist's Habit
+        IncludeSet(COLLECTION,11000,2613,ANY_ARMOR,WARRIOR,ANY_FACTION,2650,2651,2652),  -- Stones of the Walking Mountain
+    }
+    AddSetsToDatabase(VERSION, COLLECTION, sets)
+end
+
+--
+--    GLOBAL FUNCTIONS
+--
+
+function SetCollector:GetVersion10Appearances(expansion)
+    if expansion.v10 then
+        GetCraftedAppearances()
+        GetDungeonAppearances()
+        GetExpansionAppearances()
+        GetLegendaryAppearances()
+        GetOtherAppearances()
+        GetPvPAppearances()
+        GetRaidAppearances()
+    end
+end
+
+function SetCollector:GetVersion10Status()
+    return SetCollector:GetExpansionStatus("10")
+end
+
+function SetCollector:SetVersion10Status()
+    SetCollector:SetExpansionStatus("10")
+end
+

--- a/Appearances/Base.lua
+++ b/Appearances/Base.lua
@@ -12,6 +12,7 @@ SetCollector.ANY_ARMOR			= { Code = "Z", Description = "Any" }
 SetCollector.DEATHKNIGHT		= { Code = "DK", Description = "DEATHKNIGHT" }
 SetCollector.DEMONHUNTER		= { Code = "DH", Description = "DEMONHUNTER" }
 SetCollector.DRUID 			    = { Code = "DR", Description = "DRUID" }
+SetCollector.EVOKER             = { Code = "DT", Description = "EVOKER" }
 SetCollector.HUNTER 			= { Code = "HU", Description = "HUNTER" }
 SetCollector.MAGE 				= { Code = "MA", Description = "MAGE" }
 SetCollector.MONK 				= { Code = "MO", Description = "MONK" }
@@ -124,11 +125,11 @@ function SetCollector:IncludeVariant(setID, setInfo, ...)
         Order = order,
         Appearances = {}
     }
-    local sources = C_TransmogSets.GetSetSources(setID)
-    if sources then
-        variant.Count = #sources
-        for sourceID in pairs(sources) do
-            local sourceInfo = C_TransmogCollection.GetSourceInfo(sourceID);
+    local appearances = C_TransmogSets.GetSetPrimaryAppearances(setID)
+    if appearances then
+        variant.Count = #appearances
+        for pos in pairs(appearances) do
+            local sourceInfo = C_TransmogCollection.GetSourceInfo(appearances[pos].appearanceID);
             if (sourceInfo) then
                 local slotID = C_Transmog.GetSlotForInventoryType(sourceInfo.invType)
                 table.insert(variant.Appearances, SetCollector:CreateAppearance(sourceInfo.visualID or nil, sourceInfo.sourceID or nil, slotID or nil))
@@ -144,7 +145,7 @@ end
 
 function SetCollector:CreateSet(collection, uid, title, armorType, class, faction, location, ...)
     local set = {
-        ID = collection.Code..string.format("%03d", uid)..armorType.Code..class.Code..faction.Code,
+        ID = collection.Code..string.format("%04d", uid)..armorType.Code..class.Code..faction.Code,
         Title = title,
         TooltipID = SetCollector:CreateTooltipID(collection, uid, title),
         ArmorType = armorType,

--- a/DB.lua
+++ b/DB.lua
@@ -25,7 +25,8 @@ local defaults = {
 			v06 = true,
 			v07 = true,
 			v08 = true,
-			v09 = true
+			v09 = true,
+			v10 = true
 		},
 		minimap = {
 			hide = false
@@ -59,6 +60,7 @@ local ANY_ARMOR			= { Code = "Z", Description = "Any" }
 local DEATHKNIGHT 	= { Code = "DK", Description = "DEATHKNIGHT" }
 local DEMONHUNTER 	= { Code = "DH", Description = "DEMONHUNTER" }
 local DRUID 		= { Code = "DR", Description = "DRUID" }
+local EVOKER 		= { Code = "DT", Description = "EVOKER" }
 local HUNTER 		= { Code = "HU", Description = "HUNTER" }
 local MAGE 			= { Code = "MA", Description = "MAGE" }
 local MONK 			= { Code = "MO", Description = "MONK" }
@@ -474,6 +476,7 @@ function SetCollector:AddAppearances(debug)
 	SetCollector:GetVersion07Appearances(expansions)	-- Legion
 	SetCollector:GetVersion08Appearances(expansions)	-- Battle for Azeroth
 	SetCollector:GetVersion09Appearances(expansions)	-- Shadowlands
+	SetCollector:GetVersion10Appearances(expansions)	-- Dragonflight
 	
 	--if debug then SetCollector:Print("Finished adding appearances to database.") end
 end
@@ -506,6 +509,7 @@ function SetCollector:GetExpansionStatus(version)
 	elseif version == "7" then return expansions.v07
 	elseif version == "8" then return expansions.v08
 	elseif version == "9" then return expansions.v09
+	elseif version == "10" then return expansions.v10
 	end
 end
 
@@ -521,6 +525,7 @@ function SetCollector:SetExpansionStatus(version)
 	elseif version == "7" then expansions.v07 = not expansions.v07
 	elseif version == "8" then expansions.v08 = not expansions.v08
 	elseif version == "9" then expansions.v09 = not expansions.v09
+	elseif version == "10" then expansions.v10 = not expansions.v10
 	end
 end
 
@@ -761,6 +766,16 @@ function SetCollector:GetOptions()
 						desc = L["INT_OPT_EXPANSION_09_DESC"],
 						get = "GetVersion09Status",
 						set = "SetVersion09Status",
+						width = "full"
+					},
+					v10 = {
+						type = "toggle",
+						hidden = HideExpansionToggle("100000"),
+						order = 20,
+						name = L["INT_OPT_EXPANSION_10_NAME"],
+						desc = L["INT_OPT_EXPANSION_10_DESC"],
+						get = "GetVersion10Status",
+						set = "SetVersion10Status",
 						width = "full"
 					},
 				},

--- a/SetCollector.toc
+++ b/SetCollector.toc
@@ -1,4 +1,4 @@
-## Interface: 90207
+## Interface: 100000
 ## Title: Set Collector
 ## Notes: Allows the user to preview and track their progress in the collection of various transmogrification appearance sets, such as Raid, PvP and other expansion-specific sets.
 ## Version: 3.3.8
@@ -26,6 +26,7 @@ Appearances\06.lua
 Appearances\07.lua
 Appearances\08.lua
 Appearances\09.lua
+Appearances\10.lua
 DB.lua
 UI.lua
 Tooltips.lua

--- a/Tooltips.lua
+++ b/Tooltips.lua
@@ -145,10 +145,10 @@ if (AtlasLootTooltip) then hookTooltips[AtlasLootTooltip] = 1; end
 -- Global Functions
 --
 
-for tt in pairs(hookTooltips) do
-	local origHook = tt:GetScript("OnTooltipSetItem");
-	if (origHook ~= OnTooltipSetItemHook) then
-		origTooltips[tt] = origHook;
-		tt:SetScript("OnTooltipSetItem", OnTooltipSetItemHook);
-	end
-end
+-- for tt in pairs(hookTooltips) do
+-- 	local origHook = tt:GetScript("OnTooltipSetItem");
+-- 	if (origHook ~= OnTooltipSetItemHook) then
+-- 		origTooltips[tt] = origHook;
+-- 		tt:SetScript("OnTooltipSetItem", OnTooltipSetItemHook);
+-- 	end
+-- end

--- a/UI.lua
+++ b/UI.lua
@@ -60,6 +60,7 @@ local function GetClassArmorType(class)
 	if		class == "DEATHKNIGHT"	then return PLATE.Description
 	elseif	class == "DEMONHUNTER"	then return LEATHER.Description
 	elseif	class == "DRUID"		then return LEATHER.Description
+	elseif	class == "EVOKER"		then return MAIL.Description
 	elseif	class == "HUNTER"		then return MAIL.Description
 	elseif	class == "MAGE"			then return CLOTH.Description
 	elseif	class == "MONK"			then return LEATHER.Description
@@ -138,7 +139,11 @@ title:SetPoint("TOP", 0, -4)
 title:SetFrameLevel(100)
 title:SetAttribute("parentKey", "Title")
 	
-frame.TitleText:SetText(L["ADDON_NAME"])
+if frame.TitleContainer then
+	frame.TitleContainer.TitleText:SetText(L["ADDON_NAME"])
+else
+	frame.TitleText:SetText(L["ADDON_NAME"])
+end
 
 tinsert(UISpecialFrames, frame:GetName())							-- Hides frame when Escape is pressed or Game menu selected.
 
@@ -380,7 +385,7 @@ local function SetItemButton(button, appearanceID, sourceID)
 		local sTexture, sLink
 		if src and src > 0 then
 			_, _, _, sTexture, _, sLink = C_TransmogCollection.GetAppearanceSourceInfo(src)
-        end
+		end
 		if sLink and sTexture then
 			local itemID = GetItemInfoInstant(sLink);
             if itemID and itemID > 0 then
@@ -395,7 +400,10 @@ local function SetItemButton(button, appearanceID, sourceID)
                     button.icon:SetVertexColor(1, 1, 1, 1)
                     button.icon:SetDesaturated(false)
                     local iRarity = select(3, GetItemInfo(sLink))
-                    if iRarity then button.glow:SetVertexColor(GetItemQualityColor(iRarity)) end
+                    if iRarity then 
+											local r, g, b, _ = GetItemQualityColor(iRarity)
+											button.glow:SetVertexColor(r, g, b) 
+										end
                     button.glow:Show()
                 end
 
@@ -440,8 +448,15 @@ local function VariantTab_OnClick(self, button, ...)
 	end
 end
 
+local WOW_VERSION = select(4, GetBuildInfo())
+if WOW_VERSION >= 100000 then
+	TabTemplate = "PanelTabButtonTemplate"
+else
+	TabTemplate = "CharacterFrameTabButtonTemplate"
+end
+
 for i=1, 5 do
-	local variantTab = CreateFrame("Button","$parentTab"..i,setDisplay,"CharacterFrameTabButtonTemplate")
+	local variantTab = CreateFrame("Button","$parentTab"..i,setDisplay,TabTemplate)
 	variantTab:SetID(i)
 	variantTab:SetText(i)
 	if i == 1 then
@@ -484,7 +499,7 @@ function SetCollector:SetVariantTabs(collection, set, variant, outfit)
 				if ( not variantTab.FavoriteTexture ) then
 					variantTab.FavoriteTexture = variantTab:CreateTexture("$parentFavorite","OVERLAY")
 					variantTab.FavoriteTexture:SetAtlas("PetJournal-FavoritesIcon")
-					variantTab.FavoriteTexture:SetPoint("LEFT","$parentText","LEFT",-10,0)
+					variantTab.FavoriteTexture:SetPoint("LEFT",nil,"LEFT",-10,0)
 				end
 				if ( SHOW_ONLY_FAVORITE == true and not char.sets[set].variants[i].favorite ) then
 					variantTab:Hide()


### PR DESCRIPTION
Tooltips got a lot of changes just now, looks hard.  But the rest of the bugs are fixed.  You might also want to re-order some of the new sets.  I grouped them as best as I could, but some sets are actually recolors of other ones (like the base of the Aspirant PVP set is actually the World and Weekly Quests set), and the Aspirant PVP set could be listed as a variant of the other PVP sets, but they don't share base sets, so I didn't know how you wanted to handle those.  Also not sure what you want to go in "Other" vs "Expansion", or if you want all the variants of a base set to be tabs on that set, or if some variants should go into PVP or Crafting.

For Vault of the Incarnate, each base set is the Normal mode loot, but I didn't actually make sure the 3 variants corresponded with Heroic, then Mythic, then Raid Finder, in that order. 

I made up the 2-letter abbreviation for Evoker as DT (I originally had Dracthyr there), and in the set Unique Keys I stretched out the patch id from 3 to 4 characters, because 10901 became 11001, and I wanted to use that 4th digit (this will save us later, when 11901 comes out.)

I also updated the "/sc export" command, it should make sets easier in the future.  We can use it to back fix the old style sets, too.  Not sure if we want to do that, however, because one of the things I like about SetCollector is the handmade sets don't include filler armor like the Cinch of Freezing Fog from Violet Hold to complete my mage's ICC H25 set.

And, yeah, tooltips are only 4 lines of code but I went crosseyed, sorry.